### PR TITLE
Fixes 4-bit Mifare reading to return correct ID

### DIFF
--- a/src/android/src/com/chariotsolutions/nfc/plugin/Util.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/Util.java
@@ -149,7 +149,7 @@ public class Util {
             {
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                 for(int i = bytes.length-1; i >= 0; --i) out.write(bytes[i]);
-                String numeric = "" + Integer.parseInt(getHex(out.toByteArray()), 16);
+                String numeric = "" + Long.decode("0x" + getHex(out.toByteArray()));
                 while(numeric.length() < 11) { numeric = "0"+numeric; }
 
                 return addCheckDigit("0160" + numeric);


### PR DESCRIPTION
This fixes the 4-bit Mifare card reading to return the actual card ID instead of always returning empty.  This change shouldn't effect the reading of the 7-bit Mifare card IDs.